### PR TITLE
Big efficiency improvements for schedule optimizer

### DIFF
--- a/network/build.py
+++ b/network/build.py
@@ -165,7 +165,7 @@ def link_routes(route_dicts, route_pattern_dicts):
     routes = []
     for route_dict in route_dicts:
         route_id = route_dict["route_id"]
-        route = Route(id=route_id, long_name=route_dict["route_long_name"])
+        route = Route(id=route_id, long_name=route_dict["route_long_name"], route_type=route_dict.get("route_type", ""))
         matching_route_patterns = [
             route_pattern_dict
             for route_pattern_dict in route_pattern_dicts
@@ -190,32 +190,35 @@ def ensure_trips_are_sorted(trips_by_id):
         trip.stop_times = list(sorted(trip.stop_times, key=lambda st: st.time))
 
 
-def build_network_from_gtfs():
-    # Do the loading...
-    calendar_dicts = load_calendar()
-    calendar_attribute_dicts = load_calendar_attributes()
-    stop_dicts = load_stops()
-    stop_time_dicts = load_relevant_stop_times()
-    transfer_dicts = load_transfers()
-    trip_dicts = load_trips()
-    route_dicts = load_routes()
-    route_pattern_dicts = load_route_patterns()
-    shapes = load_shapes()
-    # Now do the linking...
-    station_dicts = get_stations_from_stops(stop_dicts)
-    services_by_id = link_services(calendar_dicts, calendar_attribute_dicts)
-    routes_by_id = link_routes(route_dicts, route_pattern_dicts)
-    shapes_by_id = get_shapes_by_id(shapes)
-    trips_by_id = link_trips(trip_dicts, services_by_id, shapes_by_id)
+def load_gtfs_dicts():
+    return {
+        "calendar": load_calendar(),
+        "calendar_attributes": load_calendar_attributes(),
+        "stops": load_stops(),
+        "stop_times": load_relevant_stop_times(),
+        "transfers": load_transfers(),
+        "trips": load_trips(),
+        "routes": load_routes(),
+        "route_patterns": load_route_patterns(),
+        "shapes": load_shapes(),
+    }
+
+
+def link_network_from_dicts(dicts):
+    station_dicts = get_stations_from_stops(dicts["stops"])
+    services_by_id = link_services(dicts["calendar"], dicts["calendar_attributes"])
+    routes_by_id = link_routes(dicts["routes"], dicts["route_patterns"])
+    shapes_by_id = get_shapes_by_id(dicts["shapes"])
+    trips_by_id = link_trips(dicts["trips"], services_by_id, shapes_by_id)
     stations = [link_station(d) for d in station_dicts]
     all_stops = []
     for station in stations:
-        for child_stop in link_child_stops(station, stop_dicts):
+        for child_stop in link_child_stops(station, dicts["stops"]):
             all_stops.append(child_stop)
-            link_stop_times(child_stop, stop_time_dicts, trips_by_id)
+            link_stop_times(child_stop, dicts["stop_times"], trips_by_id)
     for station in stations:
         for stop in station.child_stops:
-            link_transfers(stop, all_stops, transfer_dicts)
+            link_transfers(stop, all_stops, dicts["transfers"])
     ensure_trips_are_sorted(trips_by_id)
     return Network(
         stations_by_id=index_by(stations, lambda st: st.id),
@@ -224,3 +227,7 @@ def build_network_from_gtfs():
         routes_by_id=routes_by_id,
         services_by_id=services_by_id,
     )
+
+
+def build_network_from_gtfs():
+    return link_network_from_dicts(load_gtfs_dicts())

--- a/network/main.py
+++ b/network/main.py
@@ -1,28 +1,24 @@
 import os
 import pickle
-import sys
 
-from .build import build_network_from_gtfs
+from .build import load_gtfs_dicts, link_network_from_dicts
 from .config import PATH_TO_PICKLED_NETWORK
-
-LARGE_RECURSION_LIMIT = 10000
 
 
 def get_gtfs_network():
     if os.path.exists(PATH_TO_PICKLED_NETWORK):
-        with open(PATH_TO_PICKLED_NETWORK, "rb") as file:
-            try:
-                return pickle.load(file)
-            except Exception:
-                print("Error loading pickled network.")
-    print("Creating network from scratch...")
-    network = build_network_from_gtfs()
-    with open(PATH_TO_PICKLED_NETWORK, "wb") as file:
-        old_limit = sys.getrecursionlimit()
-        sys.setrecursionlimit(LARGE_RECURSION_LIMIT)
-        pickle.dump(network, file)
-        sys.setrecursionlimit(old_limit)
-        return network
+        try:
+            with open(PATH_TO_PICKLED_NETWORK, "rb") as f:
+                gtfs_dicts = pickle.load(f)
+            return link_network_from_dicts(gtfs_dicts)
+        except Exception:
+            print("Error loading cached GTFS data.")
+
+    print("Loading GTFS from CSV...")
+    gtfs_dicts = load_gtfs_dicts()
+    with open(PATH_TO_PICKLED_NETWORK, "wb") as f:
+        pickle.dump(gtfs_dicts, f)
+    return link_network_from_dicts(gtfs_dicts)
 
 
 if __name__ == "__main__":

--- a/network/models.py
+++ b/network/models.py
@@ -167,6 +167,7 @@ class RoutePattern(object):
 class Route(object):
     id: str
     long_name: str
+    route_type: str = ""  # GTFS route_type: 0=tram, 1=subway, 2=rail, 3=bus
     representative_trip: Trip = None
     route_patterns: List[RoutePattern] = field(default_factory=list)
 

--- a/scheduler/departures.py
+++ b/scheduler/departures.py
@@ -8,8 +8,7 @@ from synthesize.util import listify, get_pairs
 
 from scheduler.network import create_scheduler_network, SchedulerNetwork
 from scheduler.scheduling_problem import SchedulingProblem
-from scheduler.ordering import get_orderings
-from scheduler.optimize import solve_departure_offsets_for_orderings
+from scheduler.optimize import solve_departure_offsets
 
 
 @listify
@@ -83,8 +82,7 @@ def _create_departure_offset_getter(network: SchedulerNetwork) -> Dict[str, int]
             trips_per_period=route_pattern_id_to_tph,
             network=network,
         )
-        orderings = get_orderings(problem)
-        offsets = solve_departure_offsets_for_orderings(problem, orderings)
+        offsets = solve_departure_offsets(problem)
         tph_dict_cache[key] = offsets
         return offsets
 

--- a/scheduler/optimize.py
+++ b/scheduler/optimize.py
@@ -1,138 +1,155 @@
-from typing import List
-from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
 import cvxpy as cp
 
-from synthesize.util import get_pairs, listify
-
-from scheduler.network import Service, Node
-from scheduler.ordering import Ordering
 from scheduler.scheduling_problem import SchedulingProblem
 
 
-@dataclass
-class OptimizeContext:
-    ordering: Ordering
-    problem: SchedulingProblem
-
-    def __post_init__(self):
-        self._variables = {}
-
-    def _get_or_create_variable(self, name: str, **kwargs):
-        existing = self._variables.get(name)
-        if existing:
-            return existing
-        variable = cp.Variable(name=name, **kwargs)
-        self._variables[name] = variable
-        return variable
-
-    def get_departure_offset_variable(self, service: Service):
-        return self._get_or_create_variable(f"departure_offset_{service}", nonneg=True)
-
-
-def get_indexed_arrival_expression(ctx: OptimizeContext, service: Service, index: int, node: Node):
-    offset = ctx.get_departure_offset_variable(service)
-    headway = ctx.problem.get_service_headway(service)
-    trip_time = service.trip_time_to_node_seconds(node)
-    if trip_time is None:
-        raise ValueError("Got invalid trip time")
-    return offset + headway * index + trip_time
-
-
-@listify
-def get_ordered_arrival_expressions_for_node(ctx: OptimizeContext, node: Node):
-    arrivals_by_id = ctx.ordering.arrival_orderings[node]
-    for index, service in arrivals_by_id:
-        yield get_indexed_arrival_expression(ctx, service, index, node)
-
-
-@listify
-def get_constraints_for_node(ctx: OptimizeContext, node: Node):
-    arrival_expressions = get_ordered_arrival_expressions_for_node(ctx, node)
-    for arrival_expr_a, arrival_expr_b in get_pairs(arrival_expressions):
-        yield arrival_expr_a + ctx.problem.exclusion_time <= arrival_expr_b
-
-
-def get_global_constraints(ctx: OptimizeContext):
-    for idx, service in enumerate(ctx.ordering.dispatch_ordering):
-        headway = ctx.problem.get_service_headway(service)
-        offset = ctx.get_departure_offset_variable(service)
-        if idx == 0:
-            yield offset == 0
-        else:
-            yield offset + 1 <= headway
-    for service_a, service_b in get_pairs(ctx.ordering.dispatch_ordering):
-        offset_a = ctx.get_departure_offset_variable(service_a)
-        offset_b = ctx.get_departure_offset_variable(service_b)
-        yield offset_a <= offset_b
-
-
-def get_scheduler_constraints(ctx: OptimizeContext):
-    constraints = list(get_global_constraints(ctx))
-    for node in ctx.problem.nodes.values():
-        constraints += get_constraints_for_node(ctx, node)
-    return constraints
-
-
-def get_objective_for_node(ctx: OptimizeContext, node: Node):
-    obj = 0
-    total_arrivals = len(ctx.ordering.arrival_orderings[node])
-    weight = 1 / total_arrivals
-    arrival_exprs = get_ordered_arrival_expressions_for_node(ctx, node)
-    desired_headway = ctx.problem.period // total_arrivals
-    for first, second in get_pairs(arrival_exprs):
-        term = ((second - first) - desired_headway) ** 2
-        obj += term
-    first = arrival_exprs[0]
-    last = arrival_exprs[-1]
-    term = ((first + ctx.problem.period - last) - desired_headway) ** 2
-    return weight * obj
-
-
-def get_scheduler_objective(ctx: OptimizeContext):
-    obj = 0
-    for node in ctx.problem.nodes.values():
-        obj += get_objective_for_node(ctx, node)
-    return obj
-
-
-def solve_departure_offsets(problem: SchedulingProblem, ordering: Ordering):
-    ctx = OptimizeContext(problem=problem, ordering=ordering)
-    constraints = get_scheduler_constraints(ctx)
-    objective = get_scheduler_objective(ctx)
-    cvx_problem = cp.Problem(cp.Minimize(objective), constraints)
-    cvx_problem.solve()
-    if cvx_problem.status in ["infeasible", "unbounded"]:
-        return float("inf"), None, None
-    offsets = {}
-    arrivals = {}
-    for service in problem.services.values():
-        departure_offset = ctx.get_departure_offset_variable(service)
-        offsets[service.id] = round(departure_offset.value)
-    for node in problem.nodes.values():
-        exprs = get_ordered_arrival_expressions_for_node(ctx, node)
-        arrivals[node.id] = [round(e.value) for e in exprs]
-    return cvx_problem.value, offsets, arrivals
-
-
-def solve_departure_offsets_for_orderings(
+def _get_visits_at_nodes(
     problem: SchedulingProblem,
-    orderings: List[Ordering],
-    debug=True,
-):
-    best_offsets = None
-    best_arrivals = None
-    best_ordering = None
-    best_value = float("inf")
-    for ordering in orderings:
-        value, offsets, arrivals = solve_departure_offsets(problem, ordering)
-        if value < best_value:
-            best_ordering = ordering
-            best_value = value
-            best_offsets = offsets
-            best_arrivals = arrivals
+) -> Dict[str, List[Tuple[str, int]]]:
+    """For each node with active services, return a list of (service_id, trip_index) visits."""
+    visits_at_node = {}
+    for node_id, node in problem.nodes.items():
+        visits = []
+        for service_id, service in problem.services.items():
+            if node in service.calls_at_nodes:
+                tph = problem.trips_per_period.get(service_id, 0)
+                for k in range(tph):
+                    visits.append((service_id, k))
+        if len(visits) > 1:
+            visits_at_node[node_id] = visits
+    return visits_at_node
+
+
+def _count_visit_pairs(visits_at_node: Dict[str, List[Tuple[str, int]]]) -> int:
+    """Count total unordered pairs across all nodes (for binary variable allocation)."""
+    count = 0
+    for visits in visits_at_node.values():
+        n = len(visits)
+        count += n * (n - 1) // 2
+    return count
+
+
+def _count_wrap_variables(visits_at_node: Dict[str, List[Tuple[str, int]]]) -> int:
+    """Count total visits across all nodes (for period-wrap binary allocation)."""
+    return sum(len(v) for v in visits_at_node.values())
+
+
+def solve_departure_offsets(problem: SchedulingProblem, debug=True) -> Dict[str, int]:
+    """
+    Solve for departure offsets using a single MILP with binary ordering variables,
+    replacing the previous enumerate-all-orderings + QP approach.
+
+    At each shared node, binary variables determine the relative ordering of
+    train visits (mapped into canonical [0, period) time via wrap variables),
+    and big-M constraints enforce minimum exclusion time. The objective maximizes
+    the minimum gap between consecutive arrivals at each node.
+    """
+    services = problem.services
+    nodes = problem.nodes
+    period = problem.period
+    exclusion = problem.exclusion_time
+    M = period
+
+    if not services:
+        return {}
+
+    visits_at_node = _get_visits_at_nodes(problem)
+
+    offset_vars = {sid: cp.Variable(name=f"offset_{sid}", nonneg=True) for sid in services}
+
+    def raw_arrival(sid, k, node_id):
+        service = services[sid]
+        node = nodes[node_id]
+        headway = problem.get_service_headway(sid)
+        trip_time = service.trip_time_to_node_seconds(node)
+        return offset_vars[sid] + headway * k + trip_time
+
+    # Allocate all binary variables as vectors to avoid CVXPY scalar bug.
+    num_pairs = _count_visit_pairs(visits_at_node)
+    num_wraps = _count_wrap_variables(visits_at_node)
+    z_vec = cp.Variable(max(num_pairs, 1), boolean=True, name="z") if num_pairs > 0 else None
+    w_vec = cp.Variable(max(num_wraps, 1), boolean=True, name="w") if num_wraps > 0 else None
+    z_idx = 0
+    w_idx = 0
+
+    constraints = []
+
+    first_sid = next(iter(services))
+    constraints.append(offset_vars[first_sid] == 0)
+
+    for sid in services:
+        headway = problem.get_service_headway(sid)
+        constraints.append(offset_vars[sid] <= headway)
+
+    min_gap_vars = {}
+
+    for node_id, visits in visits_at_node.items():
+        n = len(visits)
+        min_gap = cp.Variable(name=f"min_gap_{node_id}", nonneg=True)
+        min_gap_vars[node_id] = min_gap
+
+        # For each visit, introduce a binary wrap variable so that canonical
+        # arrivals live in [0, period). This correctly handles services whose
+        # raw arrival times exceed one period at shared nodes.
+        canon = {}
+        for v_idx, (sid, k) in enumerate(visits):
+            raw = raw_arrival(sid, k, node_id)
+            w = w_vec[w_idx]
+            w_idx += 1
+            ca = raw - w * period
+            constraints.append(ca >= 0)
+            constraints.append(ca <= period - 1)
+            canon[(sid, k)] = ca
+
+        # Wrap-around gap via first/last canonical arrival.
+        first_arr = cp.Variable(name=f"first_{node_id}")
+        last_arr = cp.Variable(name=f"last_{node_id}")
+        for key in canon:
+            constraints.append(first_arr <= canon[key])
+            constraints.append(last_arr >= canon[key])
+        constraints.append(first_arr + period - last_arr >= min_gap)
+
+        for i in range(n):
+            for j in range(i + 1, n):
+                v_i = visits[i]
+                v_j = visits[j]
+                a_i = canon[v_i]
+                a_j = canon[v_j]
+
+                z = z_vec[z_idx]
+                z_idx += 1
+                # z=1 => i before j; z=0 => j before i (in canonical time)
+                constraints.append(a_i + exclusion - a_j <= M * (1 - z))
+                constraints.append(a_j + exclusion - a_i <= M * z)
+                constraints.append(a_j - a_i >= min_gap - M * (1 - z))
+                constraints.append(a_i - a_j >= min_gap - M * z)
+
+    if not min_gap_vars:
+        return {sid: 0 for sid in services}
+
+    objective = cp.Maximize(cp.sum(list(min_gap_vars.values())))
+    prob = cp.Problem(objective, constraints)
+    prob.solve()
+
+    if prob.status in ("infeasible", "unbounded"):
+        raise ValueError(f"Solver returned status: {prob.status}")
+
+    offsets = {sid: round(var.value) for sid, var in offset_vars.items()}
+
     if debug:
         print("---------")
-        print(best_ordering)
-        for node_id, arrivals in best_arrivals.items():
+        for node_id, visits in visits_at_node.items():
+            arrivals = []
+            for sid, k in visits:
+                service = services[sid]
+                node = nodes[node_id]
+                headway = problem.get_service_headway(sid)
+                trip_time = service.trip_time_to_node_seconds(node)
+                arr = (offsets[sid] + headway * k + trip_time) % period
+                arrivals.append(arr)
+            arrivals.sort()
             print(node_id, [a // 60 for a in arrivals])
-    return best_offsets
+
+    return offsets

--- a/scheduler/tests/test_optimize.py
+++ b/scheduler/tests/test_optimize.py
@@ -1,0 +1,81 @@
+from scheduler.network import create_scheduler_network
+from scheduler.tests.data import route_patterns
+from scheduler.scheduling_problem import SchedulingProblem
+from scheduler.optimize import solve_departure_offsets
+
+
+def _get_arrivals_at_node(problem, offsets, node_id):
+    """Compute sorted arrival times at a node for all visits."""
+    arrivals = []
+    for service_id, service in problem.services.items():
+        node = problem.nodes[node_id]
+        if node not in service.calls_at_nodes:
+            continue
+        headway = problem.get_service_headway(service_id)
+        trip_time = service.trip_time_to_node_seconds(node)
+        tph = problem.trips_per_period[service_id]
+        for k in range(tph):
+            arrivals.append(offsets[service_id] + headway * k + trip_time)
+    return sorted(arrivals)
+
+
+def _get_consecutive_gaps(arrivals, period):
+    """Return all consecutive gaps including the wrap-around."""
+    gaps = [arrivals[i + 1] - arrivals[i] for i in range(len(arrivals) - 1)]
+    gaps.append(arrivals[0] + period - arrivals[-1])
+    return gaps
+
+
+def test_solve_departure_offsets():
+    network = create_scheduler_network(route_patterns)
+    problem = SchedulingProblem(
+        trips_per_period={"x": 2, "y": 2, "z": 2},
+        network=network,
+    )
+    offsets = solve_departure_offsets(problem, debug=False)
+
+    assert set(offsets.keys()) == {"x", "y", "z"}
+    for sid in offsets:
+        headway = problem.get_service_headway(sid)
+        assert 0 <= offsets[sid] <= headway
+
+    for node_id in problem.nodes:
+        arrivals = _get_arrivals_at_node(problem, offsets, node_id)
+        if len(arrivals) < 2:
+            continue
+        gaps = _get_consecutive_gaps(arrivals, problem.period)
+        for gap in gaps:
+            assert gap >= problem.exclusion_time, (
+                f"Gap {gap}s < exclusion {problem.exclusion_time}s at node {node_id}"
+            )
+
+
+def test_single_service():
+    network = create_scheduler_network(route_patterns)
+    problem = SchedulingProblem(
+        trips_per_period={"x": 4},
+        network=network,
+    )
+    offsets = solve_departure_offsets(problem, debug=False)
+    assert "x" in offsets
+
+
+def test_two_services_even_spacing():
+    """Two services at 2 tph sharing a node should achieve ~15-min spacing (4 trains/hr at junction)."""
+    network = create_scheduler_network(route_patterns)
+    problem = SchedulingProblem(
+        trips_per_period={"x": 2, "y": 2},
+        network=network,
+    )
+    offsets = solve_departure_offsets(problem, debug=False)
+
+    for node_id in problem.nodes:
+        arrivals = _get_arrivals_at_node(problem, offsets, node_id)
+        if len(arrivals) < 2:
+            continue
+        gaps = _get_consecutive_gaps(arrivals, problem.period)
+        ideal_gap = problem.period // len(arrivals)
+        for gap in gaps:
+            assert gap >= ideal_gap * 0.5, (
+                f"Gap {gap}s much smaller than ideal {ideal_gap}s at node {node_id}"
+            )

--- a/synthesize/write_gtfs.py
+++ b/synthesize/write_gtfs.py
@@ -38,7 +38,9 @@ class GtfsWriter(object):
         self.calendar_rows = []
         self.amenity_rows = []
 
-    def add_route(self, route: Route):
+    def add_route(self, route: Route, route_type_override: str = None):
+        # Use override if provided, otherwise use route's type, default to "2" (rail) for synthetic routes
+        route_type = route_type_override or getattr(route, 'route_type', None) or "2"
         self.route_rows.append(
             {
                 "route_id": route.id,
@@ -46,7 +48,7 @@ class GtfsWriter(object):
                 "route_short_name": "",
                 "route_long_name": route.long_name,
                 "route_desc": "",
-                "route_type": "",
+                "route_type": route_type,
                 "route_url": "",
                 "route_color": "",
                 "route_text_color": "",


### PR DESCRIPTION
This whole thing was done by Claude Code; it reformulates the convex optimization problem embedded in the scheduling solver so that we don't need to check every permutation of departure times. The result is that we should be able to use this code for considerably larger interlining networks, potentially including NSRL.

Here is what Claude has to say:

-----

# Departure Offset Optimization

## Problem Statement

We operate a set of rail services $S$ that share key nodes (junctions and termini) $N$. Each service $s \in S$ runs $T_s$ trains per period $P$ (typically $P = 3600$ s), giving a headway $h_s = P / T_s$. Each service has a known travel time $\tau_{s,n}$ from its origin to each node $n$ it serves.

We need to choose a **departure offset** $o_s$ for each service — the number of seconds after the start of the period when its first train departs — such that trains are evenly spaced at every shared node. The minimum time between any two trains at the same node must be at least $\epsilon$ (the exclusion time, typically 60 s).

At each node $n$, define the set of **visits** $V_n = \{(s, k) : s \text{ calls at } n,\; k = 0, \ldots, T_s - 1\}$. The raw arrival time of visit $(s, k)$ at node $n$ is

$$r_{s,k,n} = o_s + h_s \cdot k + \tau_{s,n}$$

which is affine in the offset $o_s$.

---

## Old System: Enumerate Orderings + Convex QP

### Phase 1: Ordering Enumeration

An **ordering** $\sigma$ specifies, at each node $n$, the sequence in which visits arrive. For example, with services $x, y, z$ each at 2 tph sharing a node, one ordering might be $x_0, y_0, z_0, x_1, y_1, z_1$.

The function `get_orderings` performs a recursive tree search over all feasible orderings. At each step it:

1. Picks the next service to dispatch from a pool of remaining trips.
2. For each node the service visits, finds all feasible insertion positions in the existing arrival sequence (using interval arithmetic on `Range` objects).
3. Prunes branches where a service would exceed its headway or the sequence can't be made cyclic.

This produces a list of `Ordering` objects — one per feasible permutation.

### Phase 2: Convex QP per Ordering

For a **fixed** ordering $\sigma$, the problem becomes a convex QP. Let $a_{\sigma(i),n}$ denote the arrival expression of the $i$-th visit in the ordering at node $n$. The constraints are linear:

$$a_{\sigma(i),n} + \epsilon \leq a_{\sigma(i+1),n} \quad \forall i, n$$

The objective minimizes squared deviation from ideal headways at each node:

$$\min \sum_{n \in N} \frac{1}{|V_n|} \sum_{i=1}^{|V_n|-1} \left( a_{\sigma(i+1),n} - a_{\sigma(i),n} - d_n \right)^2 + \left( a_{\sigma(1),n} + P - a_{\sigma(|V_n|),n} - d_n \right)^2$$

where $d_n = P / |V_n|$ is the ideal gap. This is a sum-of-squares of affine expressions in the offset variables — a convex QP solved in closed form by CVXPY (via OSQP or SCS).

### Outer Loop

The solver iterates over all orderings and keeps the one with the smallest objective value:

$$o^* = \arg\min_{\sigma \in \Sigma} \; \text{QP}(\sigma)$$

### Complexity

The number of feasible orderings $|\Sigma|$ grows combinatorially. For $|S|$ services each at $T$ tph sharing a node, the number of interleavings is on the order of

$$\frac{(\sum_s T_s)!}{\prod_s T_s!}$$

(a multinomial coefficient), pruned by feasibility but still potentially $O(n!)$ in the worst case.

---

## New System: Single MILP

The new formulation folds the discrete ordering decisions into the optimization as binary variables, solving everything in one shot.

### Variables

**Offsets** (continuous):

$$o_s \in [0, h_s] \quad \forall s \in S, \qquad o_{s_1} = 0 \;\text{(symmetry-breaking)}$$

**Wrap variables** (binary, one per visit per node):

$$w_{s,k,n} \in \{0, 1\}$$

These map raw arrivals into canonical time $[0, P)$:

$$a_{s,k,n} = r_{s,k,n} - w_{s,k,n} \cdot P, \qquad 0 \leq a_{s,k,n} \leq P - 1$$

This is necessary because $r_{s,k,n}$ can exceed $P$ when travel times are large.

**Ordering variables** (binary, one per unordered pair of visits at each node):

$$z_{i,j,n} \in \{0, 1\} \quad \forall \{i, j\} \subseteq V_n$$

$z_{i,j,n} = 1$ means visit $i$ arrives before visit $j$ at node $n$ in canonical time.

**Min-gap variables** (continuous, one per node):

$$g_n \geq 0 \quad \forall n \in N$$

### Constraints

**Exclusion (big-M disjunction).** For each pair of visits $i, j$ at node $n$:

$$a_i + \epsilon - a_j \leq P \cdot (1 - z_{i,j,n})$$

$$a_j + \epsilon - a_i \leq P \cdot z_{i,j,n}$$

When $z = 1$: the first constraint enforces $a_i + \epsilon \leq a_j$; the second is slack.
When $z = 0$: vice versa.

**Min-gap (big-M).** The forward gap in the active direction must be at least $g_n$:

$$a_j - a_i \geq g_n - P \cdot (1 - z_{i,j,n})$$

$$a_i - a_j \geq g_n - P \cdot z_{i,j,n}$$

Since the minimum of all pairwise forward gaps equals the minimum consecutive gap, this correctly captures the worst-case spacing without needing to identify which pairs are adjacent.

**Wrap-around gap.** Auxiliary variables track the first and last canonical arrivals:

$$f_n \leq a_{s,k,n}, \quad \ell_n \geq a_{s,k,n} \quad \forall (s,k) \in V_n$$

$$f_n + P - \ell_n \geq g_n$$

### Objective

$$\max \sum_{n \in N} g_n$$

This maximizes the sum of worst-case gaps across all shared nodes — directly optimizing for the best worst-case passenger wait time.

### Complexity

The MILP has $O(|V_n|^2)$ binary variables per node and $O(|V_n|^2)$ constraints per node. The branch-and-bound solver explores the space of binary assignments using LP relaxation bounds to prune, which is dramatically faster than explicit enumeration for all but the smallest instances.

| Aspect | Old (enumerate + QP) | New (single MILP) |
|--------|---------------------|-------------------|
| Ordering decisions | Explicit enumeration | Binary variables in the optimization |
| Solver calls | One QP per ordering | One MILP total |
| Objective | Min sum-of-squared gap deviations | Max min consecutive gap |
| Worst-case complexity | $O(n!)$ orderings $\times$ QP solve | Branch-and-bound (exponential worst case, fast in practice) |
| Wrap-around | Handled in QP objective term | Canonical arrivals via wrap binaries |
